### PR TITLE
Updated way to define extraNavItem

### DIFF
--- a/assets/javascripts/discourse-dev-nav-item.js
+++ b/assets/javascripts/discourse-dev-nav-item.js
@@ -1,4 +1,0 @@
-(function() {
-  Discourse.HTML.setCustomHTML('extraNavItem', "<li><a href='/groups/developers'>Dev Tracker</a></li>");
-})();
-

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,4 +3,4 @@
 # version: 0.1
 # authors: Robin Ward
 
-register_asset('javascripts/discourse-dev-nav-item.js', :server_side)
+register_custom_html(extraNavItem: "<li><a href='/groups/developers'>Dev Tracker</a></li>")


### PR DESCRIPTION
As explained in this thread it is possible to register extraNavItem in the plugin.rb file 
https://meta.discourse.org/t/extension-to-allow-custom-html-defined-in-plugins/14210/2

Since Discourse.HTML does not seams to work anymore, I propose to replace it in this plugin.
